### PR TITLE
Adds DragonJobGraph

### DIFF
--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/DragonJob.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/DragonJob.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.realtime.dag.DirectedAcyclicGraph;
 import org.apache.hadoop.realtime.job.Job;
 import org.apache.hadoop.realtime.records.JobId;
 import org.apache.hadoop.security.Credentials;
@@ -37,11 +36,11 @@ import org.apache.hadoop.security.UserGroupInformation;
  * otherwises they will throw an IllegalStateException. </p>
  *
  * <p>
- * The key component of a {@link DragonJob} is a {@link DirectedAcyclicGraph},
+ * The key component of a {@link DragonJob} is a {@link DragonJobGraph},
  * which is formed by a collection of {@link DragonVertex}s and directed 
  * {@link DragonEdge}s.
  * Normally user creates the application, describes various facets of the job 
- * , sets {@link DirectedAcyclicGraph} via {@link DragonJob} , and then 
+ * , sets {@link DragonJobGraph} via {@link DragonJob} , and then 
  * submits the job and monitor its progress.
  * </p>
  * 
@@ -63,7 +62,7 @@ import org.apache.hadoop.security.UserGroupInformation;
  *                                     .processor(EventProcessor.class)
  *                                     .addFile("file.txt")
  *                                     .addFile("dict.dat")
- *                                     .addAchive("archive.zip")
+ *                                     .addArchive("archive.zip")
  *                                     .tasks(10)
  *                                     .build();
  *   DragonVertex m2 = new DragonVertex.Builder("intermediate2")
@@ -75,8 +74,7 @@ import org.apache.hadoop.security.UserGroupInformation;
  *                                       .processor(EventProcessor.class)
  *                                       .tasks(10)
  *                                       .build();
- *   DirectedAcyclicGraph<DragonVertex, DragonEdge> g = 
- *       new DirectedAcyclicGraph<DragonVertex, DragonEdge>();
+ *   DragonJobGraph g = new DragonJobGraph();
  *   // check if the graph is cyclic when adding edge
  *   g.addEdge(source, m1).parition(HashPartitioner.class);
  *   g.addEdge(source, m2).parition(HashPartitioner.class);
@@ -109,7 +107,7 @@ public class DragonJob implements Job {
   
   private JobId jobId;
   
-  private DirectedAcyclicGraph<DragonVertex, DragonEdge> jobGraph;
+  private DragonJobGraph jobGraph;
 
 
   DragonJob(final Configuration conf) throws IOException {
@@ -169,7 +167,6 @@ public class DragonJob implements Job {
   public void submit() throws IOException, InterruptedException,
       ClassNotFoundException {
     connect();
-    final FileSystem fs = FileSystem.get(conf);
     final JobSubmitter submitter =
         getJobSubmitter(cluster.getFileSystem(), cluster.getClient());
 
@@ -215,11 +212,11 @@ public class DragonJob implements Job {
     return null;
   }
   
-  public void setJobGraph(DirectedAcyclicGraph<DragonVertex, DragonEdge> jobGraph) {
+  public void setJobGraph(DragonJobGraph jobGraph) {
     this.jobGraph =  jobGraph;
   }
   
-  DirectedAcyclicGraph<DragonVertex, DragonEdge> getJobGraph() {
+  DragonJobGraph getJobGraph() {
     return jobGraph;
   }
 }

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/DragonJobGraph.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/DragonJobGraph.java
@@ -15,38 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.realtime.dag;
+package org.apache.hadoop.realtime;
 
-import java.io.Serializable;
+import org.apache.hadoop.realtime.dag.DirectedAcyclicGraph;
 
 /**
- * An internal view of edges from a {@link DirectedAcyclicGraph}
+ * {@link DragonJobGraph} is the key component of a {@link DragonJob}.
+ * It is formed by a collection of {@link DragonVertex}s and directed 
+ * {@link DragonEdge}s.
  */
-class InternalEdge<V> implements Serializable {
-  private static final long serialVersionUID = 1917792937475311485L;
+public class DragonJobGraph extends
+    DirectedAcyclicGraph<DragonVertex, DragonEdge> {
 
-  V source;
-  V target;
+  private static final long serialVersionUID = -4182450268966910597L;
 
-  InternalEdge(V source, V target) {
-    this.source = source;
-    this.target = target;
+  public DragonJobGraph() {
+    super(DragonEdge.class);
   }
-  
-  /**
-   * Get the source vertex of this edge.
-   * @return the source vertex of this edge.
-   */
-  public V getSource() {
-    return source;
-  }
-
-  /**
-   * Get the target vertex of this edge.
-   * @return the target vertex of this edge.
-   */
-  public V getTarget() {
-    return target;
-  }
-
 }

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/JobSubmitter.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/JobSubmitter.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.realtime.dag.DirectedAcyclicGraph;
 import org.apache.hadoop.realtime.records.JobId;
 import org.apache.hadoop.realtime.security.TokenCache;
 import org.apache.hadoop.realtime.security.token.delegation.DelegationTokenIdentifier;
@@ -180,16 +179,15 @@ class JobSubmitter {
     }
   }
   
-  private void writeJobDescription(
-      DirectedAcyclicGraph<DragonVertex, DragonEdge> graph, Path descFile)
+  private void writeJobDescription(DragonJobGraph graph, Path descFile)
       throws IOException {
     // Write job description to job service provider's fs
     FSDataOutputStream out =
         FileSystem.create(submitFs, descFile, new FsPermission(
             JobSubmissionFiles.JOB_FILE_PERMISSION));
     try {
-      HessianSerializer<DirectedAcyclicGraph<DragonVertex, DragonEdge>> serializer =
-          new HessianSerializer<DirectedAcyclicGraph<DragonVertex, DragonEdge>>();
+      HessianSerializer<DragonJobGraph> serializer =
+          new HessianSerializer<DragonJobGraph>();
       serializer.serialize(out, graph);
     } finally {
       out.close();
@@ -279,7 +277,7 @@ class JobSubmitter {
     // add all the command line files/ jars and archive
     // first copy them to dragon job service provider's
     // filesystem
-    DirectedAcyclicGraph<DragonVertex, DragonEdge> jobGraph = job.getJobGraph();
+    DragonJobGraph jobGraph = job.getJobGraph();
     for (DragonVertex vertex : jobGraph.vertexSet()) {
       List<String> files = vertex.getFiles();
       if (files.size() > 0) {

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/DirectedAcyclicGraph.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/DirectedAcyclicGraph.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.realtime.dag;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,7 +45,9 @@ import java.util.TreeSet;
  * multiple threads will produce undefined results.
  * </p>
  */
-public final class DirectedAcyclicGraph<V, E> {
+public class DirectedAcyclicGraph<V, E> implements Serializable {
+  private static final long serialVersionUID = -8352536912775689101L;
+
   /* vertex -> internal vertex */
   private Map<V, InternalVertex<E>> vertexMap =
       new LinkedHashMap<V, InternalVertex<E>>();
@@ -66,6 +69,9 @@ public final class DirectedAcyclicGraph<V, E> {
 
   // this update count is used to keep internal topological iterators honest
   private long topologyUpdateCount = 0;
+
+  protected DirectedAcyclicGraph() {
+  }
 
   /**
    * @param edgeClass

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/EdgeFactory.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/EdgeFactory.java
@@ -18,10 +18,14 @@
 
 package org.apache.hadoop.realtime.dag;
 
+import java.io.Serializable;
+
 /**
  * An {@link EdgeFactory} for producing edges by using a class as a factory.
  */
-public class EdgeFactory<V, E> {
+public class EdgeFactory<V, E> implements Serializable {
+  private static final long serialVersionUID = -7890706652865009651L;
+
   private final Class<? extends E> edgeClass;
 
   public EdgeFactory(Class<? extends E> edgeClass) {

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/InternalVertex.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/InternalVertex.java
@@ -1,5 +1,6 @@
 package org.apache.hadoop.realtime.dag;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -7,7 +8,9 @@ import java.util.Set;
 /**
  * An internal view of vertices.
  */
-class InternalVertex<E> {
+class InternalVertex<E> implements Serializable {
+  private static final long serialVersionUID = 337763367843853900L;
+
   Set<E> incoming;
   Set<E> outgoing;
   private transient Set<E> unmodifiableIncoming = null;

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/TopoComparator.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/TopoComparator.java
@@ -1,12 +1,15 @@
 package org.apache.hadoop.realtime.dag;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Note, this is a lazy and incomplete implementation, with assumptions that
  * inputs are in the given topoIndexMap
  */
-class TopoComparator<V> implements Comparator<V> {
+class TopoComparator<V> implements Comparator<V>, Serializable{
+  private static final long serialVersionUID = 7091580997211005045L;
+
   private TopoOrderMap<V> topoOrderMap;
 
   public TopoComparator(TopoOrderMap<V> topoOrderMap) {

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/TopoOrderMap.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/TopoOrderMap.java
@@ -1,5 +1,6 @@
 package org.apache.hadoop.realtime.dag;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -9,7 +10,8 @@ import java.util.Map;
  * For performance and flexibility uses an ArrayList for topological index to
  * vertex mapping, and a HashMap for vertex to topological index mapping.
  */
-class TopoOrderMap<V> {
+class TopoOrderMap<V> implements Serializable {
+  private static final long serialVersionUID = 7834322521006147372L;
 
   private final List<V> topoToVertex = new ArrayList<V>();
   private final Map<V, Integer> vertexToTopo =

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/Visited.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/dag/Visited.java
@@ -44,7 +44,6 @@ class Visited {
   }
 
   public void setVisited(int index) {
-    System.out.println("set visited: " + index );
     visited.set(translateIndex(index), Boolean.TRUE);
   }
 

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/job/package-info.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/job/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,38 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.realtime.dag;
-
-import java.io.Serializable;
-
-/**
- * An internal view of edges from a {@link DirectedAcyclicGraph}
- */
-class InternalEdge<V> implements Serializable {
-  private static final long serialVersionUID = 1917792937475311485L;
-
-  V source;
-  V target;
-
-  InternalEdge(V source, V target) {
-    this.source = source;
-    this.target = target;
-  }
-  
-  /**
-   * Get the source vertex of this edge.
-   * @return the source vertex of this edge.
-   */
-  public V getSource() {
-    return source;
-  }
-
-  /**
-   * Get the target vertex of this edge.
-   * @return the target vertex of this edge.
-   */
-  public V getTarget() {
-    return target;
-  }
-
-}
+@InterfaceAudience.Private
+package org.apache.hadoop.realtime.job;
+import org.apache.hadoop.classification.InterfaceAudience;

--- a/hadoop-dragon-core/src/test/java/org/apache/hadoop/realtime/dag/TestDirectedAcyclicGraph.java
+++ b/hadoop-dragon-core/src/test/java/org/apache/hadoop/realtime/dag/TestDirectedAcyclicGraph.java
@@ -19,13 +19,17 @@ package org.apache.hadoop.realtime.dag;
 
 import java.util.Iterator;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-public class TestDirectedAcyclicGraph extends TestCase {
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
+public class TestDirectedAcyclicGraph {
+
+  @Test
   public void testAddVertex() {
     // vertex type: String, edge type: String
     String vertex1 = "new vertex1";
@@ -37,6 +41,7 @@ public class TestDirectedAcyclicGraph extends TestCase {
     assertFalse(dag.containsVertex(vertex2));
   }
 
+  @Test
   public void testCycleDetection() {
     // vertex type: String, edge type: String
     String vertex1 = "new vertex1";
@@ -59,7 +64,8 @@ public class TestDirectedAcyclicGraph extends TestCase {
     assertTrue(dagRejectedEdge);
   }
   
-  public void textIteration() throws Exception {
+  @Test
+  public void testIteration() throws Exception {
     String vertex1 = "new vertex1";
     String vertex2 = "new vertex2";
     String vertex3 = "new vertex3";

--- a/hadoop-dragon-core/src/test/java/org/apache/hadoop/realtime/serialize/TestSerializer.java
+++ b/hadoop-dragon-core/src/test/java/org/apache/hadoop/realtime/serialize/TestSerializer.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.realtime.serialize;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.apache.hadoop.realtime.DragonEdge;
+import org.apache.hadoop.realtime.DragonVertex;
+import org.apache.hadoop.realtime.dag.CycleFoundException;
+import org.apache.hadoop.realtime.dag.DirectedAcyclicGraph;
+import org.apache.hadoop.realtime.event.EventProcessor;
+import org.apache.hadoop.realtime.event.EventProducer;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ */
+public class TestSerializer {
+
+  private DirectedAcyclicGraph<DragonVertex, DragonEdge> graph = null;
+
+  @Before
+  public void setUp() throws CycleFoundException {
+    DragonVertex source =
+        new DragonVertex.Builder("source").producer(EventProducer.class)
+            .processor(EventProcessor.class).tasks(10).build();
+    DragonVertex m1 =
+        new DragonVertex.Builder("intermediate1")
+            .processor(EventProcessor.class).addFile("file.txt")
+            .addFile("dict.dat").addArchive("archive.zip").tasks(10).build();
+    DragonVertex m2 =
+        new DragonVertex.Builder("intermediate2")
+            .processor(EventProcessor.class).addFile("aux").tasks(10).build();
+    DragonVertex dest =
+        new DragonVertex.Builder("dest").processor(EventProcessor.class)
+            .tasks(10).build();
+    graph =
+        new DirectedAcyclicGraph<DragonVertex, DragonEdge>(DragonEdge.class);
+    // check if the graph is cyclic when adding edge
+    graph.addEdge(source, m1);
+    graph.addEdge(source, m2);
+    graph.addEdge(m1, dest);
+    graph.addEdge(m2, dest);
+  }
+
+  @Test
+  public void serdeDagbyHessian() throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    HessianSerializer<DirectedAcyclicGraph<DragonVertex, DragonEdge>> serializer =
+        new HessianSerializer<DirectedAcyclicGraph<DragonVertex, DragonEdge>>();
+    serializer.serialize(out, graph);
+    byte[] bytes = out.toByteArray();
+
+    ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+    DirectedAcyclicGraph<DragonVertex, DragonEdge> dag =
+        serializer.deserialize(in);
+
+    Iterator<DragonVertex> iter1 = graph.iterator();
+    Iterator<DragonVertex> iter2 = dag.iterator();
+
+    while (iter1.hasNext()) {
+      assertTrue(iter2.hasNext());
+      DragonVertex next1 = iter1.next();
+      DragonVertex next2 = iter2.next();
+      assertEquals(next1.getLabel(), next2.getLabel());
+    }
+
+  }
+}


### PR DESCRIPTION
Adds a classes inherent from DirectedAcyclicGraph in order to let user define the topology of a job more conveniently and adds some unit tests on them as well
