### PR TITLE
#48 Revisits dragon state machine

### DIFF
--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/job/JobInAppMaster.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/job/JobInAppMaster.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.realtime.DragonVertex;
 import org.apache.hadoop.realtime.JobSubmissionFiles;
 import org.apache.hadoop.realtime.app.metrics.DragonAppMetrics;
 import org.apache.hadoop.realtime.client.app.AppContext;
-import org.apache.hadoop.realtime.conf.DragonConfiguration;
 import org.apache.hadoop.realtime.job.app.event.JobDiagnosticsUpdateEvent;
 import org.apache.hadoop.realtime.job.app.event.JobEvent;
 import org.apache.hadoop.realtime.job.app.event.JobEventType;
@@ -135,13 +134,12 @@ public class JobInAppMaster implements Job,
     // Can then replace task-level uber counters (MR-2424) with job-level ones
     // sent from LocalContainerLauncher, and eventually including a count of
     // of uber-AM attempts (probably sent from MRAppMaster).
-  public DragonConfiguration conf;
+  public Configuration conf;
 
   // fields initialized in init
   private FileSystem fs;
   private Path remoteJobSubmitDir;
   public Path remoteJobConfFile;
-  private int allowedFailuresPercent = 0;
   private Token<JobTokenIdentifier> jobToken;
   private JobTokenSecretManager jobTokenSecretManager;
   private final List<String> diagnostics = new ArrayList<String>();
@@ -209,6 +207,11 @@ public class JobInAppMaster implements Job,
               EnumSet.of(JobState.RUNNING, JobState.FAILED),
               JobEventType.JOB_TASK_COMPLETED,
               new TaskCompletedTransition())
+          .addTransition
+              (JobState.RUNNING,
+              EnumSet.of(JobState.RUNNING, JobState.FAILED),
+              JobEventType.JOB_COMPLETED,
+              new JobNoTasksCompletedTransition())
           .addTransition(JobState.RUNNING, JobState.KILL_WAIT,
               JobEventType.JOB_KILL, new KillTasksTransition())
           .addTransition(JobState.RUNNING, JobState.RUNNING,
@@ -293,7 +296,7 @@ public class JobInAppMaster implements Job,
   // changing fields while the job is running
   private int numTasks;
   private int completedTaskCount = 0;
-  private int failedTaskCount = 0;
+  private boolean hasTaskFailure = false;
   private int killedTaskCount = 0;
   private long startTime;
   private long finishTime;
@@ -311,7 +314,7 @@ public class JobInAppMaster implements Job,
     this.applicationAttemptId = applicationAttemptId;
     this.jobId = jobId;
     this.jobName = conf.get(DragonJobConfig.JOB_NAME, "<missing job name>");
-    this.conf = new DragonConfiguration(conf);
+    this.conf = new Configuration(conf);
     this.metrics = metrics;
     this.clock = clock;
     this.amInfos = amInfos;
@@ -585,7 +588,7 @@ public class JobInAppMaster implements Job,
         DragonJobGraph graph = createJobGraph(job);
         job.numTasks = getTaskCount(graph);
         if (job.numTasks == 0) {
-          job.addDiagnostic("No of maps and reduces are 0 " + job.jobId);
+          job.addDiagnostic("No of tasks are 0 " + job.jobId);
         }
 
         checkTaskLimits();
@@ -657,18 +660,13 @@ public class JobInAppMaster implements Job,
 
     private void createTasks(JobInAppMaster job, long inputLength,
                                 DragonJobGraph graph) {
-      // Test
-      Task testTask =
-          new TaskInAppMaster(job.jobId, job.eventHandler,
-              job.remoteJobConfFile, job.conf, job.allowedFailuresPercent,
-              job.taskAttemptListener, job.jobToken,
-              job.fsTokens.getAllTokens(), job.clock,
-              job.allowedFailuresPercent, job.metrics);
-      job.addTask(testTask);
       for (DragonVertex vertex : graph.vertexSet()) {
         for (int i = 0; i < vertex.getTasks(); i++) {
-          // TODO: implement it!
-          Task task = null;
+          Task task = new TaskInAppMaster(job.jobId, i,  job.eventHandler,
+              job.remoteJobConfFile, job.conf,
+              job.taskAttemptListener, job.jobToken,
+              job.fsTokens.getAllTokens(), job.clock,
+              job.applicationAttemptId.getAttemptId(), job.metrics);
           job.addTask(task);
         }
       }
@@ -713,6 +711,12 @@ public class JobInAppMaster implements Job,
 //          job.appSubmitTime, job.startTime);
 //      job.eventHandler.handle(new JobHistoryEvent(job.jobId, jice));
       job.metrics.runningJob(job);
+      
+      // If we have no tasks, just transition to job completed
+      if (job.numTasks == 0) {
+        job.eventHandler.handle(new JobEvent(job.jobId,
+            JobEventType.JOB_COMPLETED));
+      }
     }
   }
 
@@ -864,12 +868,12 @@ public class JobInAppMaster implements Job,
 
     protected JobState checkJobForCompletion(JobInAppMaster job) {
       // check for Job failure
-      if (job.failedTaskCount * 100 > job.allowedFailuresPercent * job.numTasks) {
+      if (job.hasTaskFailure) {
         job.setFinishTime();
 
         String diagnosticMsg = "Job failed as tasks failed. " +
-            "failedMaps:" + job.failedTaskCount + 
-            " failedReduces:" + job.failedTaskCount;
+            "failedMaps:" + job.hasTaskFailure + 
+            " failedReduces:" + job.hasTaskFailure;
         LOG.info(diagnosticMsg);
         job.addDiagnostic(diagnosticMsg);
         job.abortJob(JobState.FAILED);
@@ -881,7 +885,7 @@ public class JobInAppMaster implements Job,
     }
   
     private void taskFailed(JobInAppMaster job, Task task) {
-      job.failedTaskCount++;
+      job.hasTaskFailure = true;
       job.addDiagnostic("Task failed " + task.getID());
       job.metrics.failedTask(task);
     }
@@ -889,6 +893,18 @@ public class JobInAppMaster implements Job,
     private void taskKilled(JobInAppMaster job, Task task) {
       job.killedTaskCount++;
       job.metrics.killedTask(task);
+    }
+  }
+ 
+  // Transition class for handling jobs with no tasks
+  private static class JobNoTasksCompletedTransition implements
+      MultipleArcTransition<JobInAppMaster, JobEvent, JobState> {
+
+    @Override
+    public JobState transition(JobInAppMaster job, JobEvent event) {
+      job.setFinishTime();
+      job.abortJob(JobState.FAILED);
+      return job.finished(JobState.FAILED);
     }
   }
 

--- a/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/job/TaskInAppMaster.java
+++ b/hadoop-dragon-core/src/main/java/org/apache/hadoop/realtime/job/TaskInAppMaster.java
@@ -29,11 +29,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.realtime.DragonJobConfig;
 import org.apache.hadoop.realtime.app.metrics.DragonAppMetrics;
 import org.apache.hadoop.realtime.app.rm.ContainerFailedEvent;
-import org.apache.hadoop.realtime.conf.DragonConfiguration;
 import org.apache.hadoop.realtime.job.app.event.JobDiagnosticsUpdateEvent;
 import org.apache.hadoop.realtime.job.app.event.JobEvent;
 import org.apache.hadoop.realtime.job.app.event.JobEventType;
@@ -80,7 +80,7 @@ public class TaskInAppMaster implements Task, EventHandler<TaskEvent> {
 
   private static final Log LOG = LogFactory.getLog(TaskInAppMaster.class);
 
-  protected final DragonConfiguration conf;
+  protected final Configuration conf;
   protected final Path jobFile;
   protected final TaskAttemptListener taskAttemptListener;
   protected final EventHandler eventHandler;
@@ -177,8 +177,8 @@ public class TaskInAppMaster implements Task, EventHandler<TaskEvent> {
           // create the topology tables
           .installTopology();
 
-  public TaskInAppMaster(JobId jobId, EventHandler eventHandler,
-      Path remoteJobConfFile, DragonConfiguration conf, int id,
+  public TaskInAppMaster(JobId jobId, int partition, EventHandler eventHandler,
+      Path remoteJobConfFile, Configuration conf,
       TaskAttemptListener taskAttemptListener,
       Token<JobTokenIdentifier> jobToken,
       Collection<Token<? extends TokenIdentifier>> fsTokens, Clock clock,
@@ -194,7 +194,7 @@ public class TaskInAppMaster implements Task, EventHandler<TaskEvent> {
     // have a convention that none of the overrides depends on any
     // fields that need initialization.
     maxAttempts = getMaxAttempts();
-    taskId = DragonBuilderUtils.newTaskId(jobId, id);
+    taskId = DragonBuilderUtils.newTaskId(jobId, partition);
     this.taskAttemptListener = taskAttemptListener;
     this.eventHandler = eventHandler;
     this.metrics = metrics;


### PR DESCRIPTION
- Dragon jobs should failed fast whenever there is a task failed. Don't like it in MapReduce, a task failure may not cause the whole job fails.
- Someone may submit a job with zero tasks, we should deal with this scenario.
